### PR TITLE
カード登録画面formにid

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -3,9 +3,9 @@ $(function() {
   // Pay.jpのテスト用公開鍵
   Payjp.setPublicKey('pk_test_6cb120ab7206d36ff1052253');
 
-  var form = $("#form");
+  var form = $("#card-form");
 
-  $(".submit-btn").on('click', (function() {
+  $("#card-submit-btn").on('click', (function() {
 
     // formの送信を止める(サーバーと通信しない)
     form.find("input[type=submit]").prop("disabled", true);

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -6,7 +6,7 @@
       .card__box__text
         = "クレジットカード情報入力"
       .card__box__form
-        = form_with url: cards_path, method: :post, id: "form" do |f|
+        = form_with url: cards_path, method: :post, id: "card-form" do |f|
           .field
             = f.label :card_number, "カード番号"
             %span{ class: "must" }
@@ -42,5 +42,5 @@
               = "必須"
             = f.text_field :security_code, autofocus: true, placeholder: "カード背面の4桁または3桁の番号", class: "input"
           .actions
-            = f.submit "登録する", class: "submit-btn"
+            = f.submit "登録する", class: "submit-btn", id: "card-submit-btn"
 = render "layouts/footer"


### PR DESCRIPTION
# What
カード情報登録画面のhtml内formおよびsubmit-btnにそれぞれidを付与。
上記に伴い、payjp.jsの取得する要素名を修正。

# Why
idを付与していなかったことにより、他の関係ないフォームが送信された際にも「カード情報が正しくありません」と表示されてしまっていたため。


