### PR TITLE
ビューの修正

### DIFF
--- a/app/assets/stylesheets/_pay.scss
+++ b/app/assets/stylesheets/_pay.scss
@@ -18,7 +18,7 @@ $pointColor: rgb(224, 44, 44);
   align-items: center;
 
   &__box {
-    height: 600px;
+    min-height: 200px;
     width: 600px;
     background-color: $mainBoxFontColor;
     margin: 0 auto;
@@ -35,7 +35,7 @@ $pointColor: rgb(224, 44, 44);
     }
 
     &__all-cards {
-      height: 400px;
+      height: 200px;
       width: 600px;
       margin-top: 30px;
       padding: 10px;

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -10,7 +10,7 @@
     %br/
     = f.text_field :price, placeholder: "値段", required: true
     %br/
-    = f.select :item_status, {'新品同様': '新品同様', '多少の傷あり': '多少の傷あり'},include_blank: '選択してください', required: true
+    = f.select :item_status, { '新品同様': '新品同様', '多少の傷あり': '多少の傷あり'}, required: true
     %br/
     = f.collection_select :prefecture_id, Prefecture.all, :id, :name, autofocus: true, autocomplete: "address-level1"
     %br/

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -131,3 +131,16 @@
 
 
 = render "layouts/footer"
+
+- if user_signed_in? 
+  = link_to new_item_path, class: "btn" do
+    .purchase
+      %span.purchase--exhibition
+        出品する
+        = image_tag 'icon/icon_camera.png', height: 54, width: 54
+- else
+  = link_to root_path, class: "btn" do
+    .purchase
+      %span.purchase--exhibition
+        出品する
+        = image_tag 'icon/icon_camera.png', height: 54, width: 54

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -44,3 +44,15 @@
       = image_tag 'logo/logo-white.png', height: 45, width: 160
   %p
     ©FURIMA
+- if user_signed_in? 
+  = link_to new_item_path, class: "btn" do
+    .purchase
+      %span.purchase--exhibition
+        出品する
+        = image_tag 'icon/icon_camera.png', height: 54, width: 54
+- else
+  = link_to root_path, class: "btn" do
+    .purchase
+      %span.purchase--exhibition
+        出品する
+        = image_tag 'icon/icon_camera.png', height: 54, width: 54

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -44,15 +44,3 @@
       = image_tag 'logo/logo-white.png', height: 45, width: 160
   %p
     ©FURIMA
-- if user_signed_in? 
-  = link_to new_item_path, class: "btn" do
-    .purchase
-      %span.purchase--exhibition
-        出品する
-        = image_tag 'icon/icon_camera.png', height: 54, width: 54
-- else
-  = link_to root_path, class: "btn" do
-    .purchase
-      %span.purchase--exhibition
-        出品する
-        = image_tag 'icon/icon_camera.png', height: 54, width: 54


### PR DESCRIPTION
# What
トップページの出品アイコンが消えていたため、修正。
登録済みカードの表示ページのボックス縦幅を縮小。
商品出品時に商品状態が選択されていないとエラー画面に遷移してしまっていたため、修正。

# Why
ビューを調整することで、視覚的により快適なアプリにするため。
エラーや誤作動をなくすことで、動作的により快適なアプリにするため。