### PR TITLE
アプリ全体の挙動確認と修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 |------|----|-------|
 |user|references|null: false, foreign_key: true|
 |name|string|null: false|
-|category_id(active_hash)|integer|null: false|
+|category_id(ancestry)|integer|null: false|
 |detail|string|null: false|
 |brand|string||
 |price|integer|null: false|
@@ -21,9 +21,10 @@
 
 
 ### Association
-- has_many :images, dependent: :destroy
+- has_many :item_images, dependent: :destroy
 - belongs_to :user
 - has_one :purchase_history, dependent: :destroy
+
 
 
 ## item_imagesテーブル
@@ -35,6 +36,7 @@
 
 ### Association
 - belongs_to :item
+
 
 
 ## usersテーブル
@@ -72,18 +74,6 @@
 
 
 
-## cardsテーブル
-
-|Column|Type|Options|
-|------|----|-------|
-|user|references|null: false, foreign_key: true|
-|customer_id(token)|string|null: false|
-|card_id(token)|string|null: false|
-
-### Association
-- belongs_to :user
-
-
 ## delivery_addressesテーブル
 
 |Column|Type|Options|
@@ -106,15 +96,14 @@
 
 
 
-## item_purchase_histories
+
+## cardsテーブル
 
 |Column|Type|Options|
 |------|----|-------|
-|item|references|null: false, foreign_key: true|
-|seller|references|null: false, foreign_key: true|
-|buyer|references|foreign_key: true|
+|user|references|null: false, foreign_key: true|
+|customer_id(token)|string|null: false|
+|card_id(token)|string|null: false|
 
 ### Association
-- belongs_to :seller, class_name: 'User'
-- belongs_to :buyer, class_name: 'User'
-- belongs_to :item
+- belongs_to :user

--- a/app/assets/stylesheets/_items_form.scss
+++ b/app/assets/stylesheets/_items_form.scss
@@ -74,6 +74,21 @@
   width: 100vw;
 }
 
+@mixin default--require {
+  background-color: $red;
+  width: 40px;
+  height: 23px;
+  color: white;
+  text-align: center;
+  padding-bottom: 2px;
+  border-radius: 5px;
+  display: inline-block;
+  margin-bottom: 10px;
+}
+
+
+
+
 .new-main {
   padding: 100px 350px;
   min-height: 2100px;
@@ -219,21 +234,22 @@
       @include font-weight;
     }
 
-    .item-category {
-      @include flex-size;
-
-      &__sample {
-        @include text-align;
-        margin-bottom: 10px;
-        @include font-weight;
-      }
-
-      &__mandatory {
-        @include field-design
-      }       
+    .item-detail__category label{
+      @include text-align;
+      @include font-weight; 
+      font-size: 15px;
+      display: inline-block;
     }
 
-    .item-category__select select{
+    .item-default--require{
+      @include default--require;
+    }
+
+    .item-select-wrapper__box--select {
+      @include select;
+    }
+
+    .item-category-select__box select{
       @include select;
     }
 

--- a/app/assets/stylesheets/_items_form.scss
+++ b/app/assets/stylesheets/_items_form.scss
@@ -222,7 +222,7 @@
 
   .third-box {
     background-color: white;
-    height: 450px;     
+    min-height: 450px;     
     margin-top: 20px;
     padding: 15px 0 0 30px;         
     border: ridge;
@@ -309,7 +309,7 @@
 
   .fourth-box {
     background-color: white;
-    height: 330px;     
+    height: 400px;     
     margin-top: 20px;
     padding: 15px 0 0 30px;    
     border: ridge;

--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -7,19 +7,6 @@ $imgColor: lightblue;
 .back {
   background: $gray_white;
   padding: 40px;
-  .edit-item {
-    width: 700px;
-    margin: 0 auto;
-    display: flex;
-    justify-content: space-between;
-    &__btn {
-      text-decoration: none;
-      padding: 10px;
-      margin-right: 10px;
-      color: $white;
-      background-color: purple;
-    }
-  }
   
   .show-main {
     background-color: $white;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :move_to_signin, except: [:index]
   before_action :set_item, except: [:index, :new, :create, :get_category_children, :get_category_grandchildren]
 
   def index
@@ -13,6 +14,7 @@ class ItemsController < ApplicationController
   end
 
   def new
+
     @item = Item.new
     @item.item_images.build
 
@@ -38,6 +40,7 @@ class ItemsController < ApplicationController
   end
   
   def create
+
     @item = Item.new(item_params)
     items = Item.includes(:item_images).where(purchaser_id: nil)
     @items = items.order('created_at DESC').limit(5)
@@ -53,15 +56,16 @@ class ItemsController < ApplicationController
     @item = Item.includes(:item_images).find(params[:id])
   end
 
+    
+  def edit
+  end
+
   def update
     if @item.update(item_params)
       redirect_to root_path
     else
       render :edit
     end
-  end
-  
-  def edit
   end
 
   def destroy
@@ -80,4 +84,10 @@ class ItemsController < ApplicationController
   def set_item
     @item = Item.find(params[:id])
   end
+
+  def move_to_signin
+    redirect_to new_user_session_path unless user_signed_in?
+  end
+
+
 end

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -94,7 +94,7 @@
           .until-shipping__mandatory
             %p 必須
         .until-shipping__select
-          = f.text_field :days_until_shipping, placeholder: '(例)1日 ~ 2日で発送'
+          = f.text_field :days_until_shipping, placeholder: '(例)3日以内に発送'
 
       .fifth-box
         .standard-price

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -132,15 +132,8 @@
 
 = render "layouts/footer"
 
-- if user_signed_in? 
-  = link_to new_item_path, class: "btn" do
-    .purchase
-      %span.purchase--exhibition
-        出品する
-        = image_tag 'icon/icon_camera.png', height: 54, width: 54
-- else
-  = link_to root_path, class: "btn" do
-    .purchase
-      %span.purchase--exhibition
-        出品する
-        = image_tag 'icon/icon_camera.png', height: 54, width: 54
+= link_to new_item_path, class: "btn" do
+  .purchase
+    %span.purchase--exhibition
+      出品する
+      = image_tag 'icon/icon_camera.png', height: 54, width: 54

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,9 +1,5 @@
 = render "layouts/header"
 .back
-  .edit-item
-    - if user_signed_in? && current_user.id == @item.user_id
-      = link_to '編集', edit_item_path, class: "edit-item__btn"
-      = link_to '削除', item_path(@item), method: :delete, class: "edit-item__btn"
   .show-main
     .items__name
       = "#{@item.name}"
@@ -30,11 +26,11 @@
         %th{class: 'tbl__left'}
           カテゴリー
         %td{class: 'tbl__right'}
+          = link_to "#{@item.category.parent.parent.name}", '#', class:'tbl__link'
+          %br/
+          = link_to "#{@item.category.parent.name}", '#', class:'tbl__link'
+          %br/
           = link_to "#{@item.category.name}", '#', class:'tbl__link'
-          %br/
-          = link_to 'ベビー服(男の子用) ~95cm', '#', class:'tbl__link'
-          %br/
-          = link_to 'アウター', '#', class:'tbl__link'
       %tr
         %th{class: 'tbl__left'}
           ブランド
@@ -49,7 +45,7 @@
         %th{class: 'tbl__left'}
           送料
         %td{class: 'tbl__right'}
-          送料込（出品者負担）
+          = "#{@item.shipping_fee}"
       %tr
         %th{class: 'tbl__left'}
           発送元の地域
@@ -59,7 +55,7 @@
         %th{class: 'tbl__left'}
           発送日の目安
         %td{class: 'tbl__right'}
-          1-2日で発送
+          = "#{@item.days_until_shipping}"
 
     .option
       %ul= link_to '★ お気に入り 0', '#', class:'favorite'
@@ -84,9 +80,10 @@
           = '売り切れです'
       - else
         - if @item.user_id == current_user.id
-          = link_to edit_item_path, class:'show__btn__link' do
+          = link_to edit_item_path(@item), class:'show__btn__link' do
             = '商品情報編集'
-          = link_to '商品情報削除', '#', class:'show__btn__link'
+          = link_to item_path(@item), method: :delete, class:'show__btn__link' do
+            = '商品情報削除'
 
         - else
           = link_to buy_confirm_card_path, class:'show__btn__link' do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -55,7 +55,7 @@
         %th{class: 'tbl__left'}
           発送日の目安
         %td{class: 'tbl__right'}
-          = "#{@item.days_until_shipping}"
+          = "#{@item.days_until_shipping}日以内に発送"
 
     .option
       %ul= link_to '★ お気に入り 0', '#', class:'favorite'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
         sessions: 'users/sessions'
       }
   root 'items#index'
-  resources :items, only:[:index, :new, :create, :show, :edit, :update] do
+  resources :items, only:[:index, :new, :create, :show, :edit, :update, :destroy] do
     #Ajaxで動くアクションのルートを作成
     collection do
       get 'get_category_children', defaults: { fomat: 'json'}


### PR DESCRIPTION
# What
アプリ全体において、挙動確認および修正を行った。

### 詳細表示ページ
→不要なボタン削除
→親・子・孫カテゴリーを表示(.parentを用いて表示させた)
→ビュー側で送料、発送日を取得する記述がなかったため、追加(#{@item.shipping_fee}と#{@item.days_until_shipping})
→編集・削除ボタンにリンク追加
→発送日が数字のみの反映のため、ビューに「日以内の発送」の文言を追記

### 出品ページ
→カテゴリー選択欄CSS崩れをファイル場所移動にて解消
→子・孫カテゴリーのボックスが表示されると高さが足りなくなるため、min-hightにて解消

### 全体
→ログインしていない場合にログイン画面に遷移するメソッドを追加

### その他
READMEのDB設計修正

# Why
ユーザーが利用時にエラーが出ないようにするため