### PR TITLE
出品・編集ページの仕様変更

### DIFF
--- a/app/assets/javascripts/notifications.js
+++ b/app/assets/javascripts/notifications.js
@@ -1,0 +1,4 @@
+$(function(){
+  setTimeout("$('.notification, .notice, .alert').fadeOut('slow')", 3000);
+  });
+  

--- a/app/assets/stylesheets/_error_messages.scss
+++ b/app/assets/stylesheets/_error_messages.scss
@@ -1,7 +1,0 @@
-.alert {
-  color:#262626; 
-  background:#FFEBE8;
-  border:2px solid #990000;
-  padding:12px; font-weight:850;
-  margin-bottom: 20px;
-}

--- a/app/assets/stylesheets/_items_form.scss
+++ b/app/assets/stylesheets/_items_form.scss
@@ -369,11 +369,26 @@
       &__mandatory {
         @include field-design
       }
-    }
 
-    .until-shipping__select input{
-      @include input;
-
+      &__select {
+        display: flex;
+  
+        .select input{
+          margin-bottom: 25px;
+          height: 40px;
+          padding-left: 10px;
+          width: 300px;
+          display: flex;
+        }
+  
+        .text {
+          height: 40px;
+          margin-right: 250px;
+          line-height: 40px;
+          padding-left: 20px;
+        }
+  
+      }
     }
   }
 
@@ -415,10 +430,16 @@
       }
 
       &__text input{
-        margin-right: 50px;
-        width: 400px;
+        // margin-right:px;
+        width: 300px;
         height: 40px;
         padding-left: 10px;
+      }
+
+      .yen {
+        height: 40px;
+        margin-right: 250px;
+        line-height: 40px;
       }
     }
   }

--- a/app/assets/stylesheets/_notifications.scss
+++ b/app/assets/stylesheets/_notifications.scss
@@ -1,0 +1,17 @@
+.notification {
+  .notice {
+    height: 50px;
+    background-color: $skyblue;
+    color: $white;
+    text-align: center;
+    line-height: 50px;
+  }
+
+  .alert {
+    height: 50px;
+    background-color: $red;
+    color: $white;
+    text-align: center;
+    line-height: 50px;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,5 +19,5 @@ $shadow: 0 0 5px rgba(0,0,0,0.4);
 @import "cards";
 @import "buy_confirm";
 @import "pay";
-@import "error_messages";
+@import "notifications";
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,11 @@ class ApplicationController < ActionController::Base
     @current_user = User.find_by(id: session[:user_id])
   end
 
+  # ログインしていなければログインページに遷移
+  def move_to_signin
+    redirect_to new_user_session_path unless user_signed_in?
+  end
+
   protected
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, user_profile_attributes: [:first_name, :first_name_kana, :family_name, :family_name_kana, :birthday], delivery_addresses_attributes: [:first_name, :first_name_kana, :family_name, :family_name_kana, :postal_code, :prefecture_id, :city, :address, :building, :phone_number]] )

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -1,4 +1,5 @@
 class CardsController < ApplicationController
+  before_action :move_to_signin
   before_action :get_card_information, only: [:index, :destroy, :buy_confirm, :purchase]
   before_action :refer_to_payjp, only: [:create, :destroy, :purchase]
   before_action :get_item_information, only: [:buy_confirm, :purchase]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_signin, except: [:index]
+  before_action :move_to_signin, except: [:index, :show]
   before_action :set_item, except: [:index, :new, :create, :get_category_children, :get_category_grandchildren]
 
   def index
@@ -102,10 +102,6 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
-  end
-
-  def move_to_signin
-    redirect_to new_user_session_path unless user_signed_in?
   end
 
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -30,13 +30,10 @@ class ItemsController < ApplicationController
 
     @item = Item.new(item_params)
 
-    # renderの際にfile_fieldが消失するため、以下の記述が必要
-    # しかし、この記述をすると、画像を選択してもitem_imagesのデータが存在しないことになり、mysqlにてエラーが出る
-    @item.item_images.build
-
     if @item.save
       redirect_to root_path, notice: '出品しました'
     else
+      @item.item_images.build
       #セレクトボックスの初期値設定
       @category_parent_array = ["---"]
       #データベースから、親カテゴリーのみ抽出し、配列化

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -33,14 +33,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path, notice: '出品しました'
     else
-      @item.item_images.build
-      #セレクトボックスの初期値設定
-      @category_parent_array = ["---"]
-      #データベースから、親カテゴリーのみ抽出し、配列化
-      Category.where(ancestry: nil).each do |parent|
-        @category_parent_array << parent.name
-      end
-      render :new
+      redirect_to new_item_path, alert: '出品できませんでした'
     end
   end
 
@@ -73,31 +66,9 @@ class ItemsController < ApplicationController
 
   def update
     if @item.update(item_params)
-      redirect_to root_path
+      redirect_to root_path, notice: '出品情報を更新しました'
     else
-      @item = Item.find(params[:id])
-      @item.update(item_params)
-
-      category_grandchild = @item.category
-      category_child = category_grandchild.parent
-
-
-      @category_parent_array = []
-      Category.where(ancestry: nil).each do |parent|
-        @category_parent_array << parent.name
-      end
-
-      @category_children_array = []
-      Category.where(ancestry: category_child.ancestry).each do |children|
-        @category_children_array << children
-      end
-
-      @category_grandchildren_array = []
-      Category.where(ancestry: category_grandchild.ancestry).each do |grandchildren|
-        @category_grandchildren_array << grandchildren
-      end
-
-      render :edit
+      redirect_to edit_item_path, alert: '更新できませんでした'
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
 
-  def index  
+  def index
+    move_to_signin
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,6 +9,7 @@ class Item < ApplicationRecord
     # belongs_to_active_hash :category_ladys
     belongs_to_active_hash :prefecture
 
-  validates :user_id, :name, :category_id, :detail, :price, :item_status, :prefecture_id, :days_until_shipping, :shipping_fee, presence: true
-  validates :item_images, presence: true
+  validates :user_id, :name, :category_id, :detail, :price, :item_status, :prefecture_id, :days_until_shipping, :shipping_fee, :item_images, presence: true
+  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
+  validates :days_until_shipping, numericality: { only_integer: true }
 end

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -3,7 +3,6 @@
 .new-main 
   .parent-box
     = form_for [@item] do |f|
-      = render 'layouts/error_messages', model: f.object
       .first-box
         .image-box
           .image-box__sample
@@ -41,7 +40,7 @@
               -# 30,31行目のi.indexの次の番号から生成する方法がないか？
 
               - if @item.persisted?
-                .js-file_group{ data: { index: @item.item_images.count }}
+                .js-file_group{ data: { index: @item.item_images.length }}
                   = file_field_tag :url, name: "item[item_images_attributes][#{@item.item_images.count}][url]", class: 'js-file'                        
       .second-box 
         .item-name

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -103,7 +103,7 @@
             %p 必須
         .until-shipping__select
           .select
-            = f.text_field :days_until_shipping, placeholder: '整数1桁'
+            = f.text_field :days_until_shipping, placeholder: '半角整数1桁'
           .text
             = "日以内に発送"
 
@@ -117,7 +117,7 @@
             .price-box__mandatory
               %p 必須
           .price-box__text
-            = f.text_field :price, placeholder: '300'
+            = f.text_field :price, placeholder: '半角数字'
           .yen
             = "円"
       %br/

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -30,15 +30,6 @@
                   = i.file_field :url, class: "js-file", data:{ index: i.index }
                 - if @item.persisted?
                   = i.check_box :_destroy, data:{ index: i.index }, class: 'hidden-destroy'
-
-              -# 編集ページにて、renderで遷移後に画像を選択するとindexの数字がかぶってしまう
-              -# 原因
-              -# countで、DBに保存されている画像の枚数の数字でindexを作ってしまう
-              -# その結果、元々ある画像のindex(HTMLで指定している)と数字かぶってしまう
-              -# 解決したいこと
-              -# 上記以外に、indexの数字の増やし方がないか？
-              -# 30,31行目のi.indexの次の番号から生成する方法がないか？
-
               - if @item.persisted?
                 .js-file_group{ data: { index: @item.item_images.length }}
                   = file_field_tag :url, name: "item[item_images_attributes][#{@item.item_images.count}][url]", class: 'js-file'                        
@@ -64,7 +55,6 @@
         .item-detail__category
           = f.label 'カテゴリー', class: 'item-default__label'
           .item-default--require 必須
-          -# # 「孫カテゴリがあるかどうか？」といった条件分岐でどこまでフォームを表示させるかを変える
           .item-select-wrapper
             .item-select-wrapper__box
               = f.select :category_id, @category_parent_array, {selected:@item.category.parent.parent.name}, {class: 'item-select-wrapper__box--select', id: 'parent_category'}
@@ -112,7 +102,10 @@
           .until-shipping__mandatory
             %p 必須
         .until-shipping__select
-          = f.text_field :days_until_shipping, placeholder: '(例)3日以内に発送'
+          .select
+            = f.text_field :days_until_shipping, placeholder: '整数1桁'
+          .text
+            = "日以内に発送"
 
       .fifth-box
         .standard-price
@@ -124,7 +117,9 @@
             .price-box__mandatory
               %p 必須
           .price-box__text
-            = f.text_field :price, placeholder: '300円'
+            = f.text_field :price, placeholder: '300'
+          .yen
+            = "円"
       %br/
       .items-submit-btn
         = f.submit '出品する', class: "form-container__contents--btn"

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -28,11 +28,6 @@
               = f.fields_for :item_images do |i|
                 .js-file_group{ data: { index: i.index }}
                   = i.file_field :url, class: "js-file", data:{ index: i.index }
-                -# - if @item.persisted?
-                -#   = i.check_box :_destroy, data:{ index: i.index }, class: 'hidden-destroy'
-              -# - if @item.persisted?
-              -#   .js-file_group{ data: { index: @item.item_images.count }}
-              -#     = file_field_tag :url, name: "item[item_images_attributes][#{@item.item_images.count}][url]", class: 'js-file'                        
       .second-box 
         .item-name
           .item-name__sample
@@ -92,11 +87,14 @@
           = f.collection_select :prefecture_id, Prefecture.all, :id, :name, autofocus: true, autocomplete: 'address-level1'
         .until-shipping
           .until-shipping__sample
-            %p 発送までの日数
+            %p 発送までの日数 (例)3日以内に発送
           .until-shipping__mandatory
             %p 必須
         .until-shipping__select
-          = f.text_field :days_until_shipping, placeholder: '(例)3日以内に発送'
+          .select
+            = f.text_field :days_until_shipping, placeholder: '整数1桁'
+          .text
+            = "日以内に発送"
 
       .fifth-box
         .standard-price
@@ -108,7 +106,9 @@
             .price-box__mandatory
               %p 必須
           .price-box__text
-            = f.text_field :price, placeholder: '300円'
+            = f.text_field :price, placeholder: '300'
+          .yen
+            = "円"
       %br/
       .items-submit-btn
         = f.submit '出品する', class: "form-container__contents--btn"

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -3,7 +3,6 @@
 .new-main 
   .parent-box
     = form_for [@item] do |f|
-      = render 'layouts/error_messages', model: f.object
       .first-box
         .image-box
           .image-box__sample

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -92,7 +92,7 @@
             %p 必須
         .until-shipping__select
           .select
-            = f.text_field :days_until_shipping, placeholder: '整数1桁'
+            = f.text_field :days_until_shipping, placeholder: '半角整数1桁'
           .text
             = "日以内に発送"
 
@@ -106,7 +106,7 @@
             .price-box__mandatory
               %p 必須
           .price-box__text
-            = f.text_field :price, placeholder: '300'
+            = f.text_field :price, placeholder: '半角数字'
           .yen
             = "円"
       %br/

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -75,19 +75,22 @@
         %i.fas.fa-comment
         コメントする
     .show__btn
-      - if @item.purchaser_id.present?
-        .show__btn__sout
-          = '売り切れです'
-      - else
-        - if @item.user_id == current_user.id
-          = link_to edit_item_path(@item), class:'show__btn__link' do
-            = '商品情報編集'
-          = link_to item_path(@item), method: :delete, class:'show__btn__link' do
-            = '商品情報削除'
-
+      - if user_signed_in?
+        - if @item.purchaser_id.present?
+          .show__btn__sout
+            = '売り切れです'
         - else
-          = link_to buy_confirm_card_path, class:'show__btn__link' do
-            = '購入画面へ'
+          - if @item.user_id == current_user.id
+            = link_to edit_item_path(@item), class:'show__btn__link' do
+              = '商品情報編集'
+            = link_to item_path(@item), method: :delete, class:'show__btn__link' do
+              = '商品情報削除'
+          - else
+            = link_to buy_confirm_card_path, class:'show__btn__link' do
+              = '購入画面へ'
+      - else
+        = link_to buy_confirm_card_path, class:'show__btn__link' do
+          = '購入画面へ'
   .page
     %ul=link_to '< 前の商品', '#', class:'page__prev'
     %ul=link_to '後ろの商品 >', '#', class:'page__next'

--- a/app/views/layouts/_error_messages.html.haml
+++ b/app/views/layouts/_error_messages.html.haml
@@ -1,5 +1,0 @@
--if model.errors.any? 
-  .alert
-    %ul
-      -model.errors.full_messages.each do |message| 
-        %li= message

--- a/app/views/layouts/_notifications.html.haml
+++ b/app/views/layouts/_notifications.html.haml
@@ -1,0 +1,3 @@
+.notification
+  - flash.each do |key, value|
+    = content_tag :div, value, class: key

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,4 +9,5 @@
     = stylesheet_link_tag 'application', media: 'all'
     = javascript_include_tag 'application'
   %body
+    = render 'layouts/notifications'
     = yield


### PR DESCRIPTION
# What
出品および編集ページにて、商品情報に不備があった場合にredirect_toで画面遷移するように変更。
その際、出品できたかどうかの通知とアラートが表示される。

# Why
バリデーションに引っかかった際に商品情報が保存されないようにするため。
また、通知とアラートに関して、正常に保存されたかどうかユーザーが把握するため。